### PR TITLE
Fixes assertion to check length instead of end position

### DIFF
--- a/endianness.js
+++ b/endianness.js
@@ -38,7 +38,7 @@
  * @throws {Error} If the buffer length is not valid.
  */
 export default function endianness(bytes, offset, start=0, end=bytes.length) {
-  if (end % offset) {
+  if ((end - start) % offset) {
     throw new Error("Bad buffer length.");
   }
   for (let index = start; index < end; index += offset) {


### PR DESCRIPTION
For example, swapping 4 bytes from start=2 to end=6 is valid, but the previous code would fail because 6 % 4 != 0. The correct check is (end-start) % offset — 4 % 4 == 0.